### PR TITLE
adds warning also to readthedocs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,15 @@
 Welcome to Horiba Python SDK's documentation!
 =============================================
+'horiba-sdk' is a package that provides source code for the development with Horiba devices.
+
+The package is available on PyPI and can be installed using pip.
+See the github readme for a getting started video.
+
 
 .. warning::
-   TODO: write introduction
+   This SDK is under development and not yet released.
+   For this python code to work, the SDK from Horiba has to be purchased, installed and licensed.
+   The code in this repo and the SDK are under development and not yet released for public use!
 
 Contents
 --------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "horiba-sdk"
-version = "0.3.3"
+version = "0.3.5"
 description = "'horiba-sdk' is a package that provides source code for the development with Horiba devices"
 readme = "README.md"
 authors = ["ZühlkeEngineering <nikolaus.naredi-rainer@zuehlke.com>"]


### PR DESCRIPTION
## Description

adds warning to readthedocs

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/ThatsTheEnd/horiba-python-sdk/blob/master/CODE_OF_CONDUCT.md) document.
- [X] I've read the [`CONTRIBUTING.md`](https://github.com/ThatsTheEnd/horiba-python-sdk/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
